### PR TITLE
feat: GA4 tag on dev.paperos.com (Developer API docs)

### DIFF
--- a/layouts/partials/hook_head_end.html
+++ b/layouts/partials/hook_head_end.html
@@ -1,0 +1,10 @@
+<!-- Google tag (gtag.js) — PaperOS Public Site stream; query strings stripped -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1GD1GWRDVC"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-1GD1GWRDVC', {
+    page_location: location.origin + location.pathname
+  });
+</script>


### PR DESCRIPTION
Adds the PaperOS Public Site GA4 tag (`G-1GD1GWRDVC`) via the Hugo `hook_head_end` partial so dev.paperos.com is measured with the other public sites. `page_location` strips query strings. Approved by Matt 2026-07-09 as part of the GA reorganization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)